### PR TITLE
Removed PHP close tags

### DIFF
--- a/lint/linter/ClangFormatLinter.php
+++ b/lint/linter/ClangFormatLinter.php
@@ -75,5 +75,3 @@ final class ClangFormatLinter extends ArcanistExternalLinter {
     return array($message);
   }
 }
-
-?>


### PR DESCRIPTION
PHP coding standard for Phabricator provides "Use "<?php", not the "<?" short form. Omit the closing "?>" tag.".
