### PR TITLE
fix undefined offset error from 7f2f7db1

### DIFF
--- a/lint/linter/ClangFormatLinter.php
+++ b/lint/linter/ClangFormatLinter.php
@@ -115,12 +115,13 @@ final class ClangFormatLinter extends ArcanistExternalLinter {
 
         /* Next error */
         $cur_error += 1;
-        $error = $errors[$cur_error];
 
         /* We might have found all errors, early exit */
         if ($cur_error == count($errors)) {
           break;
         }
+
+        $error = $errors[$cur_error];
       }
       /* We also ned to break out of this loop */
       if ($cur_error == count($errors)) {


### PR DESCRIPTION
i'm not sure if there's something weird with my setup, but i always see errors like this with the new functionality in 7f2f7db1 without this fix.
```
[2019-09-15 21:54:18] ERROR 8: Undefined offset: 21 at [/usr/local/phabricator/clang-format-linter/lint/linter/ClangFormatLinter.php:118]
arcanist(head=master, ref.master=4a223ef6f3b4, custom=2), objc-format-linter(head=master, ref.master=7f2f7db1b745), phutil(head=master, ref.master=7e25d8904a70)
  #0 ClangFormatLinter::parseLinterOutput(string, integer, string, string) called at [<arcanist>/src/lint/linter/ArcanistExternalLinter.php:437]
```