### PR TITLE
implement getVersion() to enable version comparison

### DIFF
--- a/lint/linter/ClangFormatLinter.php
+++ b/lint/linter/ClangFormatLinter.php
@@ -60,6 +60,16 @@ final class ClangFormatLinter extends ArcanistExternalLinter {
     return $options;
   }
 
+  public function getVersion() {
+    list($stdout, $stderr) = execx(
+      '%C --version', $this->getExecutableCommand());
+    $matches = null;
+    if (preg_match('/clang-format version (\d(?:\.\d){2})/', $stdout, $matches)) {
+      return $matches[1];
+    }
+    return null;
+  }
+
   protected function parseLinterOutput($path, $err, $stdout, $stderr) {
     $messages = array();
     $errors = array();


### PR DESCRIPTION
Tested this out in a local C++ project that is using this arcanist linter. With clang-format `9.0.0` installed, it ran perfectly fine when configured with `"version": ">=8.0.1"` but provides the correct error message when I changed it to `"version": ">=9.0.1"`:
```
$ arc lint
 Exception
Linter ClangFormatLinter requires clang-format version >=9.0.1. You have version 9.0.0.
(Run with `--trace` for a full exception trace.)
```

Signed-off-by: Derek Argueta <dereka@pinterest.com>