### PR TITLE
Handle empty files being passed to clang-format

### DIFF
--- a/lint/linter/ClangFormatLinter.php
+++ b/lint/linter/ClangFormatLinter.php
@@ -74,7 +74,7 @@ final class ClangFormatLinter extends ArcanistExternalLinter {
     $messages = array();
     $errors = array();
 
-    if ($err != 0) {
+    if ($err != 0 || strlen($stdout) == 0) {
       return $messages;
     }
 


### PR DESCRIPTION
clang-format-linter can throw exceptions when the passed in file is empty, resulting in upstream issues and obscure errors for arcanist. This change handles the invariant of file stubs being passed in.